### PR TITLE
Update README and HTML for rebranding to Enterprise AI & Kubernetes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# Kubekite - AI Infrastructure & Platform Engineering
+# Kubekite - Enterprise AI & Kubernetes Platforms
 
-Static website for Kubekite, positioned around AI infrastructure, Kubernetes, GitOps, GPU orchestration, inference serving, operational runbooks, AI SRE workflows, observability, security, and cost optimization.
+Static website for Kubekite, positioned around secure AI-ready cloud platforms on AWS and Kubernetes with EKS, GitOps, Argo CD, Vault/IAM, GPU readiness, operational runbooks, AI SRE workflows, observability, and cost optimization.
 
 ## Features
 
 - Single-page consulting homepage
 - Productized service offering sections
+- Specialized service tracks for EKS, GitOps, DevSecOps, platform engineering, and cost optimization
+- Platform blueprint section
 - AI platform capabilities section
 - Architecture-style platform visual
 - Smooth anchor navigation
@@ -25,6 +27,7 @@ Static website for Kubekite, positioned around AI infrastructure, Kubernetes, Gi
 - Hero and assessment CTA
 - Platform trust strip
 - Productized offerings
+- Platform blueprint
 - AI platform capabilities
 - Operating model
 - Founder-led credibility

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -215,7 +215,8 @@ h3 {
 }
 
 .hero-proof span,
-.card-kicker {
+.card-kicker,
+.inline-link {
   display: inline-flex;
   align-items: center;
   min-height: 30px;
@@ -226,6 +227,14 @@ h3 {
   color: var(--muted);
   font-size: 0.82rem;
   font-weight: 700;
+}
+
+.inline-link {
+  min-height: 38px;
+  margin-top: 8px;
+  color: var(--brand-dark);
+  border-color: rgba(18, 108, 122, 0.22);
+  background: rgba(18, 108, 122, 0.08);
 }
 
 .architecture-card {
@@ -419,8 +428,101 @@ h3 {
   background: var(--brand);
 }
 
+.service-tracks {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  margin-top: 28px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.service-tracks div {
+  min-height: 148px;
+  padding: 22px;
+  background: #ffffff;
+}
+
+.service-tracks span {
+  display: block;
+  margin-bottom: 10px;
+  color: var(--brand);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.service-tracks strong {
+  display: block;
+  color: var(--ink);
+  font-size: 1rem;
+  line-height: 1.45;
+}
+
 .platform-section {
   background: var(--surface-soft);
+}
+
+.blueprint-section {
+  background: var(--ink);
+  color: #ffffff;
+}
+
+.blueprint-section h2,
+.blueprint-section .section-heading p:not(.eyebrow) {
+  color: #ffffff;
+}
+
+.blueprint-section .section-heading p:not(.eyebrow) {
+  color: #b8c6ce;
+}
+
+.blueprint-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.68fr) minmax(0, 1fr);
+  gap: 42px;
+  align-items: start;
+}
+
+.blueprint-map {
+  display: grid;
+  gap: 12px;
+}
+
+.blueprint-lane {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.65fr) repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.blueprint-lane span,
+.blueprint-lane strong {
+  display: flex;
+  align-items: center;
+  min-height: 62px;
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.07);
+  line-height: 1.25;
+}
+
+.blueprint-lane span {
+  color: #8fb4bd;
+  font-size: 0.77rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.blueprint-lane strong {
+  color: #ffffff;
+  font-size: 0.95rem;
 }
 
 .capabilities-section {
@@ -620,6 +722,7 @@ h3 {
   }
 
   .hero-grid,
+  .blueprint-grid,
   .platform-grid,
   .why-panel {
     grid-template-columns: 1fr;
@@ -630,6 +733,7 @@ h3 {
   }
 
   .offerings-grid,
+  .service-tracks,
   .capabilities-grid,
   .trust-grid,
   .why-metrics {
@@ -672,6 +776,7 @@ h3 {
   }
 
   .offerings-grid,
+  .service-tracks,
   .capabilities-grid,
   .trust-grid,
   .why-metrics,
@@ -681,6 +786,10 @@ h3 {
 
   .offering-card {
     min-height: auto;
+  }
+
+  .blueprint-lane {
+    grid-template-columns: 1fr;
   }
 
   .footer-grid,

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Kubekite - AI Infrastructure & Platform Engineering</title>
-  <meta name="description" content="Kubekite helps teams build secure, production-ready AI infrastructure with Kubernetes, GitOps, GPU orchestration, inference serving, runbooks, observability, and cost control.">
+  <title>Kubekite - Enterprise AI & Kubernetes Platforms</title>
+  <meta name="description" content="Kubekite helps startups and enterprises deploy secure AI and Kubernetes platforms on AWS with EKS, GitOps, Argo CD, Vault, observability, GPU readiness, and cost control.">
   <meta name="keywords" content="AI infrastructure, platform engineering, Kubernetes, EKS, GitOps, Argo CD, DevOps, GPU orchestration, AI SRE, inference serving, cloud cost optimization">
   <link rel="preload" href="assets/css/styles.css" as="style">
   <link rel="stylesheet" href="assets/css/styles.css">
@@ -18,34 +18,34 @@
     </a>
     <nav class="site-nav" aria-label="Primary navigation">
       <a href="#offerings">Offerings</a>
+      <a href="#blueprint">Blueprint</a>
       <a href="#capabilities">Capabilities</a>
-      <a href="#platform">Platform</a>
       <a href="#why">Why Kubekite</a>
       <a href="#assessment">Assessment</a>
     </nav>
-    <a class="nav-cta" href="#assessment">Book Assessment</a>
+    <a class="nav-cta" href="#assessment">Book Review</a>
   </header>
 
   <main id="home">
     <section class="hero section-band">
       <div class="section-inner hero-grid">
         <div class="hero-copy reveal">
-          <p class="eyebrow">AI Infrastructure & Platform Engineering</p>
-          <h1>Production-ready AI systems need more than a model.</h1>
+          <p class="eyebrow">Enterprise AI & Kubernetes Platforms</p>
+          <h1>Secure AI-ready platforms on AWS and Kubernetes.</h1>
           <p class="hero-lede">
-            Kubekite helps engineering teams design, deploy, and operate secure AI platforms across Kubernetes,
-            GitOps, GPU orchestration, inference serving, operational runbooks, observability, and cost controls.
+            Kubekite helps startups and enterprise teams design, deploy, and operate production platforms for
+            modern cloud and AI workloads using EKS, GitOps, Argo CD, Vault, observability, and cost controls.
           </p>
           <div class="hero-actions">
-            <a class="button primary" href="#assessment">Book an AI Platform Assessment</a>
-            <a class="button secondary" href="#offerings">View Offerings</a>
+            <a class="button primary" href="#assessment">Book Architecture Review</a>
+            <a class="button secondary" href="#blueprint">See Platform Blueprint</a>
           </div>
           <div class="hero-proof" aria-label="Core capabilities">
+            <span>AWS / EKS</span>
             <span>Kubernetes</span>
-            <span>GitOps</span>
+            <span>Argo CD</span>
+            <span>Vault / IAM</span>
             <span>AI SRE</span>
-            <span>Inference</span>
-            <span>GPU readiness</span>
           </div>
         </div>
 
@@ -98,19 +98,19 @@
       <div class="section-inner trust-grid">
         <div>
           <span>01</span>
-          <strong>Kubernetes foundations</strong>
+          <strong>EKS and Kubernetes platforms</strong>
         </div>
         <div>
           <span>02</span>
-          <strong>GitOps delivery</strong>
+          <strong>GitOps and Argo CD delivery</strong>
         </div>
         <div>
           <span>03</span>
-          <strong>AI data and inference paths</strong>
+          <strong>Vault, IAM, and DevSecOps</strong>
         </div>
         <div>
           <span>04</span>
-          <strong>AI SRE and cost control</strong>
+          <strong>AI workloads, SRE, and cost control</strong>
         </div>
       </div>
     </section>
@@ -119,19 +119,20 @@
       <div class="section-inner">
         <div class="section-heading reveal">
           <p class="eyebrow">Productized services</p>
-          <h2>Focused engagements for AI-ready platforms.</h2>
+          <h2>Focused engagements for AI and Kubernetes platforms.</h2>
           <p>
-            Start with a defined outcome, then expand into implementation and enablement as your platform matures.
+            Start with a defined architecture outcome, then expand into implementation and enablement as your
+            cloud platform matures.
           </p>
         </div>
 
         <div class="offerings-grid">
           <article class="offering-card reveal">
-            <span class="card-kicker">Starter platform</span>
+            <span class="card-kicker">AWS foundation</span>
             <h3>AI Platform Starter</h3>
             <p>
-              Build the foundation for AI workloads with Kubernetes, GitOps, CI/CD, secrets, observability,
-              AI data storage, and a clean deployment path for model or RAG services.
+              Build a production foundation for AI workloads with EKS or Kubernetes, GitOps, CI/CD, secrets,
+              observability, AI data storage, and deployment paths for model or RAG services.
             </p>
             <ul>
               <li>EKS or Kubernetes platform baseline</li>
@@ -155,7 +156,7 @@
           </article>
 
           <article class="offering-card reveal">
-            <span class="card-kicker">Efficiency review</span>
+            <span class="card-kicker">Cost and scale</span>
             <h3>Cloud & AI Cost Optimization</h3>
             <p>
               Identify waste, improve workload placement, and prepare for GPU or AI demand without letting cloud
@@ -168,6 +169,79 @@
             </ul>
           </article>
         </div>
+
+        <div class="service-tracks reveal" aria-label="Specialized service tracks">
+          <div>
+            <span>AI Infrastructure</span>
+            <strong>Secure RAG, inference, model deployment, and evaluation paths.</strong>
+          </div>
+          <div>
+            <span>Kubernetes Platforms</span>
+            <strong>EKS modernization, multi-cluster operations, and runtime standards.</strong>
+          </div>
+          <div>
+            <span>GitOps & Argo CD</span>
+            <strong>App-of-apps, environment promotion, rollback, and auditability.</strong>
+          </div>
+          <div>
+            <span>DevSecOps</span>
+            <strong>Vault, IAM, policy controls, secrets, and secure delivery practices.</strong>
+          </div>
+          <div>
+            <span>Platform Engineering</span>
+            <strong>Reusable platform patterns, runbooks, enablement, and developer workflows.</strong>
+          </div>
+          <div>
+            <span>Cloud Cost Optimization</span>
+            <strong>Kubernetes spend, workload sizing, GPU readiness, and scaling strategy.</strong>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="blueprint" class="section-band blueprint-section">
+      <div class="section-inner blueprint-grid">
+        <div class="section-heading reveal">
+          <p class="eyebrow">Platform blueprint</p>
+          <h2>A practical reference architecture for production AI.</h2>
+          <p>
+            Kubekite focuses on the pieces AI teams usually underestimate: secure delivery, identity, runtime
+            operations, data paths, observability, and cost-aware scaling.
+          </p>
+          <a class="inline-link" href="#assessment">Request a blueprint review</a>
+        </div>
+        <div class="blueprint-map reveal" aria-label="AI platform blueprint">
+          <div class="blueprint-lane">
+            <span>Source & Delivery</span>
+            <strong>GitHub / CI</strong>
+            <strong>Argo CD</strong>
+            <strong>Policy Gates</strong>
+          </div>
+          <div class="blueprint-lane">
+            <span>Platform Runtime</span>
+            <strong>AWS / EKS</strong>
+            <strong>Multi-Cluster</strong>
+            <strong>GPU Pools</strong>
+          </div>
+          <div class="blueprint-lane">
+            <span>Security</span>
+            <strong>Vault</strong>
+            <strong>IAM / IRSA</strong>
+            <strong>Network Controls</strong>
+          </div>
+          <div class="blueprint-lane">
+            <span>AI Workloads</span>
+            <strong>RAG Services</strong>
+            <strong>Inference APIs</strong>
+            <strong>Evaluation Jobs</strong>
+          </div>
+          <div class="blueprint-lane">
+            <span>Operations</span>
+            <strong>Metrics / Logs</strong>
+            <strong>Runbooks</strong>
+            <strong>Cost Signals</strong>
+          </div>
+        </div>
       </div>
     </section>
 
@@ -178,7 +252,7 @@
           <h2>The operational layer around modern AI.</h2>
           <p>
             Kubekite turns fast-moving AI experiments into reliable platform capabilities your engineering team can
-            deploy, test, troubleshoot, and scale.
+            deploy, test, troubleshoot, secure, and scale.
           </p>
         </div>
 
@@ -224,7 +298,7 @@
           <h2>From experiments to production operations.</h2>
           <p>
             AI initiatives move quickly, but production systems still need deployment discipline, secure access,
-            incident visibility, and cost accountability.
+            incident visibility, cloud governance, and cost accountability.
           </p>
         </div>
         <div class="capability-list reveal">
@@ -256,8 +330,8 @@
         </div>
         <p>
           Kubekite is built around senior DevOps and platform engineering experience: Kubernetes operations,
-          GitOps delivery, cloud architecture, security integration, AI data paths, operational runbooks, and the
-          practical tradeoffs that show up when systems move from demos to real users.
+          EKS modernization, GitOps delivery, cloud architecture, Vault and IAM integration, AI data paths,
+          operational runbooks, and the practical tradeoffs that show up when systems move from demos to real users.
         </p>
         <div class="why-metrics" aria-label="Kubekite strengths">
           <div>
@@ -280,10 +354,10 @@
       <div class="section-inner">
         <div class="assessment-intro reveal">
           <p class="eyebrow">Book an assessment</p>
-          <h2>Find the fastest safe path to an AI-ready platform.</h2>
+          <h2>Book an architecture review for your AI or Kubernetes platform.</h2>
           <p>
             Share where your team is today. Kubekite will review your goals and help identify the platform,
-            security, delivery, and cost decisions that matter first.
+            security, delivery, operating model, and cost decisions that matter first.
           </p>
         </div>
         <div class="form-shell reveal">
@@ -313,9 +387,10 @@
       </div>
       <div class="footer-links" aria-label="Footer links">
         <a href="#offerings">Offerings</a>
+        <a href="#blueprint">Blueprint</a>
         <a href="#capabilities">Capabilities</a>
         <a href="#why">Why Kubekite</a>
-        <a href="#assessment">Book Assessment</a>
+        <a href="#assessment">Book Review</a>
       </div>
     </div>
     <div class="section-inner footer-bottom">


### PR DESCRIPTION
Update README and HTML for rebranding to Enterprise AI & Kubernetes platforms; enhance styles for service tracks and blueprint sections.