### PR TITLE
Make the theme toggle legible and drop the percentage copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,15 @@ Core message:
 
 ## Content model
 
-The site is deliberately weighted **90% knowledge, 10% services**:
+The site is deliberately weighted toward knowledge, with services kept small:
 
-- **90% knowledge** — a topic-led knowledge base covering the six disciplines, plus engineering notes,
-  explainers, weekly news context and open-source examples.
-- **10% services** — a single compact band offering selective infrastructure help for teams that want
+- **Knowledge** — a topic-led knowledge base covering the six disciplines, plus engineering notes,
+  explainers, weekly news context and open-source examples. This is nearly all of the page.
+- **Services** — a single compact band offering selective infrastructure help for teams that want
   direct support after reading the work.
+
+Keep this balance when adding sections: the site is a front door to the writing, the GitHub repos
+and the newsletter, not a services pitch.
 
 ## Knowledge areas
 

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -171,29 +171,43 @@ p {
 
 .theme-toggle {
   display: inline-flex;
-  width: 38px;
-  height: 38px;
+  min-height: 42px;
   align-items: center;
-  justify-content: center;
   flex: none;
-  padding: 0;
+  padding: 0 14px;
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  background: var(--surface);
+  background: var(--surface-soft);
   color: var(--ink);
+  font: inherit;
+  font-size: 0.86rem;
+  font-weight: 750;
+  line-height: 1.2;
   cursor: pointer;
-  transition: color 160ms ease, border-color 160ms ease, transform 160ms ease;
+  transition: color 160ms ease, border-color 160ms ease, background 160ms ease, transform 160ms ease;
 }
 
 .theme-toggle:hover {
   border-color: var(--brand);
+  background: var(--surface);
   color: var(--brand);
   transform: translateY(-1px);
 }
 
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+.theme-face {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
 .theme-toggle svg {
-  width: 18px;
-  height: 18px;
+  width: 17px;
+  height: 17px;
   fill: none;
   stroke: currentColor;
   stroke-width: 1.8;
@@ -201,24 +215,24 @@ p {
   stroke-linejoin: round;
 }
 
-.theme-toggle .icon-sun {
+.theme-face-light {
   display: none;
 }
 
-:root[data-theme="dark"] .theme-toggle .icon-sun {
-  display: block;
+:root[data-theme="dark"] .theme-face-light {
+  display: inline-flex;
 }
 
-:root[data-theme="dark"] .theme-toggle .icon-moon {
+:root[data-theme="dark"] .theme-face-dark {
   display: none;
 }
 
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .theme-toggle .icon-sun {
-    display: block;
+  :root:not([data-theme="light"]) .theme-face-light {
+    display: inline-flex;
   }
 
-  :root:not([data-theme="light"]) .theme-toggle .icon-moon {
+  :root:not([data-theme="light"]) .theme-face-dark {
     display: none;
   }
 }

--- a/index.html
+++ b/index.html
@@ -38,13 +38,19 @@
     </nav>
     <div class="header-actions">
       <button class="theme-toggle" type="button" id="theme-toggle" aria-label="Switch to dark theme" aria-pressed="false" title="Switch theme">
-        <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path d="M20 14.5A8.2 8.2 0 0 1 9.5 4a8.5 8.5 0 1 0 10.5 10.5Z"></path>
-        </svg>
-        <svg class="icon-sun" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <circle cx="12" cy="12" r="4.2"></circle>
-          <path d="M12 2.6v2.2M12 19.2v2.2M4.2 12H2M22 12h-2.2M6.4 6.4 4.9 4.9M19.1 19.1l-1.5-1.5M6.4 17.6l-1.5 1.5M19.1 4.9l-1.5 1.5"></path>
-        </svg>
+        <span class="theme-face theme-face-dark">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M20 14.5A8.2 8.2 0 0 1 9.5 4a8.5 8.5 0 1 0 10.5 10.5Z"></path>
+          </svg>
+          Dark
+        </span>
+        <span class="theme-face theme-face-light">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <circle cx="12" cy="12" r="4.2"></circle>
+            <path d="M12 2.6v2.2M12 19.2v2.2M4.2 12H2M22 12h-2.2M6.4 6.4 4.9 4.9M19.1 19.1l-1.5-1.5M6.4 17.6l-1.5 1.5M19.1 4.9l-1.5 1.5"></path>
+          </svg>
+          Light
+        </span>
       </button>
       <a class="nav-cta" href="#newsletter">Subscribe</a>
     </div>
@@ -309,7 +315,7 @@
       <div class="section-inner split-layout">
         <div class="section-heading reveal">
           <p class="eyebrow">Why KubeKite</p>
-          <h2>Ninety percent knowledge. Ten percent services.</h2>
+          <h2>Knowledge first. Services second.</h2>
         </div>
         <div class="text-stack reveal">
           <p>
@@ -322,8 +328,8 @@
             so the knowledge base leads and stays open to everyone.
           </p>
           <p>
-            Services are the remaining ten percent: a small, selective practice for teams that want direct help
-            after reading the work. They fund the writing; they never shape it.
+            Services stay deliberately small: a selective practice for teams that want direct help after
+            reading the work. They fund the writing; they never shape it.
           </p>
         </div>
       </div>
@@ -370,7 +376,7 @@
     <section id="services" class="services-strip" aria-label="Selective services">
       <div class="section-inner services-bar reveal">
         <div class="services-copy">
-          <p class="eyebrow">Services — the other 10%</p>
+          <p class="eyebrow">Services</p>
           <h3>Selective infrastructure help, when a team needs it directly.</h3>
           <p>
             A small advisory practice alongside the writing: cloud and Kubernetes review, reliability and SLO


### PR DESCRIPTION
- Give the theme button a visible text label ("Dark" / "Light") next to the icon, sized to match the Subscribe button. The icon-only square read as decoration rather than a control.
- Add a focus-visible outline so the control is keyboard-discoverable.
- Remove the 90/10 percentages from the page. That split was internal direction for how to weight the site, not copy meant for visitors, so the section now says "Knowledge first. Services second." and the services eyebrow is just "Services".