### PR TITLE
Make dark the default theme and replace Services with Trends and Repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,17 @@ Core message:
 
 ## Content model
 
-The site is deliberately weighted toward knowledge, with services kept small:
+The site publishes three things, all free:
 
-- **Knowledge** — a topic-led knowledge base covering the six disciplines, plus engineering notes,
-  explainers, weekly news context and open-source examples. This is nearly all of the page.
-- **Services** — a single compact band offering selective infrastructure help for teams that want
-  direct support after reading the work.
+- **Knowledge** (`#topics`) — a topic-led base covering the six disciplines in depth.
+- **Trends** (`#trends`) — a weekly read on what is moving across the software and computing
+  landscape, published to LinkedIn and collected in KubeKite Weekly.
+- **Repos** (`#repos`) — open-source work that makes engineers faster: Claude Code hooks, skills and
+  agents, context and memory files, and starter kits.
 
-Keep this balance when adding sections: the site is a front door to the writing, the GitHub repos
-and the newsletter, not a services pitch.
+The site is a front door to the writing, the GitHub repos and the newsletter. Keep it small: prefer
+merging or removing sections over adding them, and do not ship placeholder content with invented
+dates or links that go nowhere. There is deliberately no services section — that comes later.
 
 ## Knowledge areas
 
@@ -33,12 +35,14 @@ Each area has its own card in the `#topics` section with the subtopics it covers
 ## Features
 
 - Static GitHub Pages-compatible homepage
-- Navigation: Home, Topics, Insights, Latest, About and Contact
+- Navigation: Home, Topics, Trends, Repos, About and Contact
+- **Dark theme by default**, with light as an explicit opt-in via the header toggle. The choice is
+  stored in `localStorage` under `kubekite-theme` and applied by an inline pre-paint script so it
+  does not flash. Colours are CSS custom properties: dark values live on `:root`, light values on
+  `:root[data-theme="light"]` — add new colours as tokens in both blocks, never as literals.
 - Topic-led knowledge base as the primary section
-- Insights section describing the publishing formats: Engineering Notes, KubeKite Explains,
-  KubeKite Weekly and open source
-- Latest section with one starter post per knowledge area
-- Compact single-band services strip
+- Trends section covering the wider software and computing landscape
+- Repos section for open-source work, linking the GitHub org
 - Founder-led About preview
 - Newsletter placeholder for KubeKite Weekly
 - Existing Google Form contact mechanism

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,45 +1,5 @@
+/* Dark is the default theme. Light applies only when the visitor opts in. */
 :root {
-  color-scheme: light;
-
-  --bg: #f7f9fc;
-  --surface: #ffffff;
-  --surface-soft: #eef3f7;
-  --ink: #14212f;
-  --muted: #5f6d7a;
-  --line: #dbe4ea;
-  --brand: #126c7a;
-  --brand-dark: #0b4350;
-  --on-brand: #ffffff;
-  --accent: #d97706;
-  --success: #0d9488;
-
-  --cta-bg: #14212f;
-  --cta-text: #ffffff;
-  --header-bg: rgba(247, 249, 252, 0.94);
-  --header-line: rgba(219, 228, 234, 0.86);
-  --hero-fade: #ffffff;
-  --hero-glow: rgba(18, 108, 122, 0.12);
-  --grid-line: rgba(219, 228, 234, 0.58);
-  --grid-bg: #fbfdff;
-  --flow-card-bg: rgba(255, 255, 255, 0.95);
-  --accent-soft: #fffaf2;
-
-  /* The focus strip and footer stay dark in both themes. */
-  --band-bg: #14212f;
-  --band-text: #d9e2e8;
-  --band-muted: #8fa0ac;
-  --band-line: rgba(255, 255, 255, 0.14);
-  --band-accent: #5cc4d4;
-
-  --shadow: 0 18px 42px rgba(20, 33, 47, 0.08);
-  --shadow-card: 0 12px 28px rgba(20, 33, 47, 0.05);
-  --shadow-button: 0 14px 28px rgba(11, 67, 80, 0.18);
-
-  --radius: 8px;
-  --max-width: 1160px;
-}
-
-:root[data-theme="dark"] {
   color-scheme: dark;
 
   --bg: #0b131c;
@@ -65,6 +25,7 @@
   --flow-card-bg: rgba(19, 30, 42, 0.95);
   --accent-soft: #241a0d;
 
+  /* The focus strip and footer stay dark in both themes. */
   --band-bg: #060d14;
   --band-text: #d3dee7;
   --band-muted: #8496a6;
@@ -74,45 +35,46 @@
   --shadow: 0 18px 42px rgba(0, 0, 0, 0.5);
   --shadow-card: 0 12px 28px rgba(0, 0, 0, 0.38);
   --shadow-button: 0 14px 28px rgba(42, 157, 176, 0.22);
+
+  --radius: 8px;
+  --max-width: 1160px;
 }
 
-/* No stored choice and no JS: follow the operating system. */
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
-    color-scheme: dark;
+:root[data-theme="light"] {
+  color-scheme: light;
 
-    --bg: #0b131c;
-    --surface: #131e2a;
-    --surface-soft: #172431;
-    --ink: #e7eef4;
-    --muted: #9cabba;
-    --line: #263546;
-    --brand: #5cc4d4;
-    --brand-dark: #2a9db0;
-    --on-brand: #04191f;
-    --accent: #f0a44a;
-    --success: #2dd4bf;
+  --bg: #f7f9fc;
+  --surface: #ffffff;
+  --surface-soft: #eef3f7;
+  --ink: #14212f;
+  --muted: #5f6d7a;
+  --line: #dbe4ea;
+  --brand: #126c7a;
+  --brand-dark: #0b4350;
+  --on-brand: #ffffff;
+  --accent: #d97706;
+  --success: #0d9488;
 
-    --cta-bg: #e7eef4;
-    --cta-text: #0b131c;
-    --header-bg: rgba(11, 19, 28, 0.92);
-    --header-line: rgba(38, 53, 70, 0.9);
-    --hero-fade: #131e2a;
-    --hero-glow: rgba(92, 196, 212, 0.1);
-    --grid-line: rgba(38, 53, 70, 0.55);
-    --grid-bg: #0f1922;
-    --flow-card-bg: rgba(19, 30, 42, 0.95);
-    --accent-soft: #241a0d;
+  --cta-bg: #14212f;
+  --cta-text: #ffffff;
+  --header-bg: rgba(247, 249, 252, 0.94);
+  --header-line: rgba(219, 228, 234, 0.86);
+  --hero-fade: #ffffff;
+  --hero-glow: rgba(18, 108, 122, 0.12);
+  --grid-line: rgba(219, 228, 234, 0.58);
+  --grid-bg: #fbfdff;
+  --flow-card-bg: rgba(255, 255, 255, 0.95);
+  --accent-soft: #fffaf2;
 
-    --band-bg: #060d14;
-    --band-text: #d3dee7;
-    --band-muted: #8496a6;
-    --band-line: rgba(255, 255, 255, 0.1);
+  --band-bg: #14212f;
+  --band-text: #d9e2e8;
+  --band-muted: #8fa0ac;
+  --band-line: rgba(255, 255, 255, 0.14);
+  --band-accent: #5cc4d4;
 
-    --shadow: 0 18px 42px rgba(0, 0, 0, 0.5);
-    --shadow-card: 0 12px 28px rgba(0, 0, 0, 0.38);
-    --shadow-button: 0 14px 28px rgba(42, 157, 176, 0.22);
-  }
+  --shadow: 0 18px 42px rgba(20, 33, 47, 0.08);
+  --shadow-card: 0 12px 28px rgba(20, 33, 47, 0.05);
+  --shadow-button: 0 14px 28px rgba(11, 67, 80, 0.18);
 }
 
 * {
@@ -215,26 +177,17 @@ p {
   stroke-linejoin: round;
 }
 
-.theme-face-light {
+/* Default is dark, so the button offers "Light"; light mode offers "Dark". */
+.theme-face-dark {
   display: none;
 }
 
-:root[data-theme="dark"] .theme-face-light {
+:root[data-theme="light"] .theme-face-dark {
   display: inline-flex;
 }
 
-:root[data-theme="dark"] .theme-face-dark {
+:root[data-theme="light"] .theme-face-light {
   display: none;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .theme-face-light {
-    display: inline-flex;
-  }
-
-  :root:not([data-theme="light"]) .theme-face-dark {
-    display: none;
-  }
 }
 
 .brand {
@@ -269,13 +222,11 @@ p {
 }
 
 .site-nav a,
-.footer-links a,
-.article-card a {
+.footer-links a {
   transition: color 160ms ease;
 }
 
-.site-nav a:hover,
-.article-card a:hover {
+.site-nav a:hover {
   color: var(--brand);
 }
 
@@ -459,7 +410,6 @@ h3 {
 .system-flow span,
 .capability-card span,
 .topic-card > span,
-.article-meta span,
 .contact-topics span,
 .focus-grid span {
   display: block;
@@ -514,8 +464,7 @@ h3 {
   gap: 16px;
 }
 
-.capability-card,
-.article-card {
+.capability-card {
   min-height: 230px;
   padding: 22px;
   border: 1px solid var(--line);
@@ -525,18 +474,39 @@ h3 {
 }
 
 .capability-card h3,
-.topic-card h3,
-.article-card h3 {
+.topic-card h3 {
   margin-top: 18px;
 }
 
-.capability-card p,
-.article-card p {
+.capability-card p {
   margin-bottom: 0;
 }
 
 .soft-section {
   background: var(--surface-soft);
+}
+
+.section-footnote {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+  margin-top: 20px;
+}
+
+.section-footnote p {
+  margin-bottom: 0;
+  font-size: 0.94rem;
+}
+
+.repo-panel {
+  max-width: none;
+  margin-top: 20px;
+}
+
+.contact-card p a {
+  color: var(--brand);
+  font-weight: 750;
 }
 
 .split-layout {
@@ -558,38 +528,6 @@ h3 {
 
 .text-stack p {
   margin-bottom: 0;
-}
-
-.article-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 16px;
-}
-
-.article-card {
-  display: flex;
-  flex-direction: column;
-}
-
-.article-meta {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 10px;
-  color: var(--muted);
-  font-size: 0.78rem;
-}
-
-.article-meta time {
-  color: var(--muted);
-}
-
-.article-card a {
-  margin-top: auto;
-  padding-top: 20px;
-  color: var(--brand-dark);
-  font-size: 0.9rem;
-  font-weight: 800;
 }
 
 .topic-grid {
@@ -634,31 +572,6 @@ h3 {
   color: var(--muted);
   font-size: 0.78rem;
   font-weight: 650;
-}
-
-.services-strip {
-  padding: 28px 22px;
-  background: var(--surface-soft);
-  border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line);
-}
-
-.services-bar {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 24px;
-  align-items: center;
-}
-
-.services-copy h3 {
-  margin-bottom: 6px;
-  font-size: 1.02rem;
-}
-
-.services-copy p {
-  max-width: 720px;
-  margin-bottom: 0;
-  font-size: 0.92rem;
 }
 
 .newsletter-section,
@@ -841,14 +754,8 @@ h3 {
 
   .capability-grid,
   .topic-grid,
-  .article-grid,
   .focus-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .services-bar {
-    grid-template-columns: 1fr;
-    justify-items: start;
   }
 
   .footer-grid {
@@ -895,14 +802,12 @@ h3 {
 
   .capability-grid,
   .topic-grid,
-  .article-grid,
   .focus-grid {
     grid-template-columns: 1fr;
   }
 
   .capability-card,
   .topic-card,
-  .article-card,
   .text-stack,
   .newsletter-panel,
   .system-flow {
@@ -910,8 +815,7 @@ h3 {
   }
 
   .capability-card,
-  .topic-card,
-  .article-card {
+  .topic-card {
     min-height: auto;
   }
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -3,8 +3,9 @@ document.documentElement.classList.add("js");
 const THEME_KEY = "kubekite-theme";
 const themeToggle = document.querySelector("#theme-toggle");
 
+// Dark is the default, so anything other than an explicit "light" counts as dark.
 const currentTheme = () =>
-  document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light";
+  document.documentElement.getAttribute("data-theme") === "light" ? "light" : "dark";
 
 const applyTheme = (theme) => {
   document.documentElement.setAttribute("data-theme", theme);
@@ -29,22 +30,6 @@ if (themeToggle) {
       localStorage.setItem(THEME_KEY, nextTheme);
     } catch (error) {
       // Storage can be unavailable in private mode; the toggle still works for this visit.
-    }
-  });
-}
-
-if (window.matchMedia) {
-  window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (event) => {
-    let stored = null;
-
-    try {
-      stored = localStorage.getItem(THEME_KEY);
-    } catch (error) {
-      stored = null;
-    }
-
-    if (!stored) {
-      applyTheme(event.matches ? "dark" : "light");
     }
   });
 }

--- a/index.html
+++ b/index.html
@@ -9,14 +9,13 @@
   <link rel="preload" href="assets/css/styles.css" as="style">
   <link rel="stylesheet" href="assets/css/styles.css">
   <script>
-    // Runs before first paint so the saved theme does not flash the wrong colours.
+    // Dark is the default. Runs before first paint so a stored light choice does not flash dark.
     (function () {
       try {
         var stored = localStorage.getItem("kubekite-theme");
-        var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-        document.documentElement.setAttribute("data-theme", stored || (prefersDark ? "dark" : "light"));
+        document.documentElement.setAttribute("data-theme", stored === "light" ? "light" : "dark");
       } catch (error) {
-        document.documentElement.setAttribute("data-theme", "light");
+        document.documentElement.setAttribute("data-theme", "dark");
       }
     })();
   </script>
@@ -31,8 +30,8 @@
     <nav class="site-nav" aria-label="Primary navigation">
       <a href="#home">Home</a>
       <a href="#topics">Topics</a>
-      <a href="#insights">Insights</a>
-      <a href="#latest">Latest</a>
+      <a href="#trends">Trends</a>
+      <a href="#repos">Repos</a>
       <a href="#about">About</a>
       <a href="#contact">Contact</a>
     </nav>
@@ -67,12 +66,12 @@
             Engineering, MLOps, Cloud Computing, AI Infrastructure and Platform Engineering.
           </p>
           <p class="hero-note">
-            Everything here is written to teach: engineering notes, plain-language explainers, weekly news with
-            context and open-source examples you can read, run and reuse.
+            Three things, all free: explainers on how the pieces work, a weekly read on what is moving across the
+            software and computing landscape, and open-source repos that make the daily work easier.
           </p>
           <div class="hero-actions">
             <a class="button primary" href="#topics">Explore Topics</a>
-            <a class="button secondary" href="#newsletter">Subscribe</a>
+            <a class="button secondary" href="#repos">Browse Repos</a>
           </div>
         </div>
 
@@ -207,135 +206,93 @@
       </div>
     </section>
 
-    <section id="insights" class="section-band soft-section">
+    <section id="trends" class="section-band soft-section">
       <div class="section-inner">
         <div class="section-heading reveal">
-          <p class="eyebrow">Insights</p>
-          <h2>How the knowledge is published</h2>
+          <p class="eyebrow">Trends</p>
+          <h2>What is moving across the landscape</h2>
           <p>
-            Four formats, all education-first, for engineers who want less noise and more practical infrastructure judgment.
+            A weekly read on software and computing: what shipped, what broke, what teams are adopting and what
+            is quietly being abandoned. Signal and context, not press releases.
           </p>
         </div>
 
         <div class="capability-grid">
           <article class="capability-card reveal">
-            <span>KubeKite Engineering Notes</span>
-            <h3>Real infrastructure lessons</h3>
-            <p>EKS upgrades, Terraform patterns, GitOps, SLO design, incidents, migrations and operational tradeoffs.</p>
+            <span>Platforms &amp; Infrastructure</span>
+            <h3>How systems get built and run</h3>
+            <p>Cloud services, Kubernetes, delivery tooling and the operational shifts behind them.</p>
           </article>
           <article class="capability-card reveal">
-            <span>KubeKite Explains</span>
-            <h3>Clear technical explainers</h3>
-            <p>Kubernetes, cloud services, reliability practice, MLOps pipelines, GPUs, Ray, CI/CD and developer tooling.</p>
+            <span>AI &amp; Model Infrastructure</span>
+            <h3>The stack underneath the models</h3>
+            <p>GPUs, inference serving, agent tooling and what running AI workloads actually costs.</p>
           </article>
           <article class="capability-card reveal">
-            <span>KubeKite Weekly</span>
-            <h3>News with engineering context</h3>
-            <p>Cloud, DevOps, SRE, security, platform engineering and AI infrastructure updates without generic noise.</p>
+            <span>Developer Experience</span>
+            <h3>What teams actually adopt</h3>
+            <p>Editors, CI, code review and automation — the tools that change how engineers spend a day.</p>
           </article>
           <article class="capability-card reveal">
-            <span>Open Source</span>
-            <h3>Repos that teach by example</h3>
-            <p>Small templates, diagrams, reference architectures and starter kits you can read end to end.</p>
+            <span>Industry Signals</span>
+            <h3>Launches, deprecations, direction</h3>
+            <p>Notable releases and end-of-life notices, read for what they mean for the work ahead.</p>
           </article>
+        </div>
+
+        <div class="section-footnote reveal">
+          <p>Published weekly on LinkedIn, with the highlights collected in KubeKite Weekly.</p>
+          <a class="button secondary" href="https://www.linkedin.com/company/kubekite/" rel="noopener">Follow on LinkedIn</a>
         </div>
       </div>
     </section>
 
-    <section id="latest" class="section-band">
+    <section id="repos" class="section-band">
       <div class="section-inner">
         <div class="section-heading reveal">
-          <p class="eyebrow">Latest</p>
-          <h2>Start here</h2>
+          <p class="eyebrow">Repos</p>
+          <h2>Smart work, packaged up</h2>
           <p>
-            Initial content tracks across the six topics. These are placeholders until the first real posts and repos are published.
+            Open-source repos aimed at the everyday grind — setups and templates that make engineers faster,
+            especially when working alongside AI tooling. Free to clone, read and adapt.
           </p>
         </div>
 
-        <div class="article-grid">
-          <article class="article-card reveal">
-            <div class="article-meta">
-              <span>DevOps</span>
-              <time datetime="2026-08-12">Aug 12, 2026</time>
-            </div>
-            <h3>EKS upgrade lessons to document early</h3>
-            <p>Turn upgrade work into reusable notes instead of losing hard-earned platform knowledge after every migration.</p>
-            <a href="#newsletter" aria-label="Read EKS upgrade lessons placeholder">5 min read</a>
+        <div class="capability-grid">
+          <article class="capability-card reveal">
+            <span>Claude Code Hooks</span>
+            <h3>Automate the repetitive parts</h3>
+            <p>Hooks that run checks, formatting and guardrails automatically instead of relying on memory.</p>
           </article>
-          <article class="article-card reveal">
-            <div class="article-meta">
-              <span>SRE</span>
-              <time datetime="2026-08-12">Aug 12, 2026</time>
-            </div>
-            <h3>Writing an SLO your team will actually defend</h3>
-            <p>Choosing indicators that reflect user pain, and using the error budget as a decision tool rather than a report.</p>
-            <a href="#newsletter" aria-label="Read SLO design placeholder">6 min read</a>
+          <article class="capability-card reveal">
+            <span>Skills &amp; Agents</span>
+            <h3>Task-shaped helpers</h3>
+            <p>Reusable skills and agent definitions for reviews, migrations and repeatable engineering work.</p>
           </article>
-          <article class="article-card reveal">
-            <div class="article-meta">
-              <span>MLOps</span>
-              <time datetime="2026-08-12">Aug 12, 2026</time>
-            </div>
-            <h3>What breaks between training and serving</h3>
-            <p>Feature skew, versioning gaps and the handoffs that quietly turn a good model into a bad prediction.</p>
-            <a href="#newsletter" aria-label="Read training to serving placeholder">6 min read</a>
+          <article class="capability-card reveal">
+            <span>Context &amp; Memory Files</span>
+            <h3>Give the tools real context</h3>
+            <p>Markdown context, project memory and conventions that make AI assistants useful on real codebases.</p>
           </article>
-          <article class="article-card reveal">
-            <div class="article-meta">
-              <span>Cloud Computing</span>
-              <time datetime="2026-08-12">Aug 12, 2026</time>
-            </div>
-            <h3>Landing zones without the enterprise jargon</h3>
-            <p>Why multi-account structure exists, what problem it solves and how much of it a small team really needs.</p>
-            <a href="#newsletter" aria-label="Read landing zones placeholder">5 min read</a>
+          <article class="capability-card reveal">
+            <span>Starter Kits</span>
+            <h3>Reference setups worth copying</h3>
+            <p>Small reference architectures and templates that show a working setup end to end.</p>
           </article>
-          <article class="article-card reveal">
-            <div class="article-meta">
-              <span>AI Infrastructure</span>
-              <time datetime="2026-08-12">Aug 12, 2026</time>
-            </div>
-            <h3>Kubernetes plus GPUs, explained simply</h3>
-            <p>GPU scheduling, runtime isolation, workload placement and observability explained for infrastructure engineers.</p>
-            <a href="#newsletter" aria-label="Read Kubernetes plus GPUs placeholder">6 min read</a>
-          </article>
-          <article class="article-card reveal">
-            <div class="article-meta">
-              <span>Platform Engineering</span>
-              <time datetime="2026-08-12">Aug 12, 2026</time>
-            </div>
-            <h3>Golden paths that developers choose willingly</h3>
-            <p>What makes a paved road adopted instead of bypassed, and how platform teams measure whether it worked.</p>
-            <a href="#newsletter" aria-label="Read golden paths placeholder">5 min read</a>
-          </article>
+        </div>
+
+        <div class="contact-card repo-panel reveal">
+          <h3>Available now</h3>
+          <p>
+            <a href="https://github.com/KubeKite/workflow-builder" rel="noopener">workflow-builder</a> — a workflow
+            automation platform. More repos land here as they are published.
+          </p>
+          <a class="button primary" href="https://github.com/KubeKite" rel="noopener">Browse the GitHub org</a>
         </div>
       </div>
     </section>
 
-    <section id="why" class="section-band soft-section">
-      <div class="section-inner split-layout">
-        <div class="section-heading reveal">
-          <p class="eyebrow">Why KubeKite</p>
-          <h2>Knowledge first. Services second.</h2>
-        </div>
-        <div class="text-stack reveal">
-          <p>
-            KubeKite exists to explain modern infrastructure. Almost all of the work here is publishing:
-            engineering notes, explainers, weekly news context, diagrams and open-source examples across
-            DevOps, SRE, MLOps, Cloud, AI Infrastructure and Platform Engineering.
-          </p>
-          <p>
-            That is deliberate. Free, careful, specific writing is how engineers learn and how trust gets built —
-            so the knowledge base leads and stays open to everyone.
-          </p>
-          <p>
-            Services stay deliberately small: a selective practice for teams that want direct help after
-            reading the work. They fund the writing; they never shape it.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <section id="about" class="section-band">
+    <section id="about" class="section-band soft-section">
       <div class="section-inner split-layout">
         <div class="section-heading reveal">
           <p class="eyebrow">About</p>
@@ -373,26 +330,12 @@
       </div>
     </section>
 
-    <section id="services" class="services-strip" aria-label="Selective services">
-      <div class="section-inner services-bar reveal">
-        <div class="services-copy">
-          <p class="eyebrow">Services</p>
-          <h3>Selective infrastructure help, when a team needs it directly.</h3>
-          <p>
-            A small advisory practice alongside the writing: cloud and Kubernetes review, reliability and SLO
-            practice, platform engineering, and infrastructure for AI workloads.
-          </p>
-        </div>
-        <a class="button secondary" href="#contact">Enquire</a>
-      </div>
-    </section>
-
     <section id="contact" class="section-band contact-section">
       <div class="section-inner">
         <div class="contact-intro reveal">
           <p class="eyebrow">Contact</p>
           <h2>Follow, read or collaborate.</h2>
-          <p>KubeKite is focused on education and open-source traction. Reach out about the content, the repos, or selective infrastructure help.</p>
+          <p>KubeKite is focused on education and open-source work. Reach out about the writing, the repos, or a trend worth covering.</p>
         </div>
         <div class="contact-topics reveal" aria-label="Contact topics">
           <span>DevOps</span>
@@ -405,7 +348,7 @@
         <div class="contact-card reveal">
           <h3>Have a question, correction or topic request?</h3>
           <p>
-            Use the existing KubeKite form for content ideas, repo feedback, corrections, collaboration or selective platform help.
+            Use the existing KubeKite form for content ideas, repo feedback, corrections or collaboration.
           </p>
           <a class="button primary" href="https://docs.google.com/forms/d/e/1FAIpQLSfk7C1w_3CgMhnOai2XXtlCQxVvNY1yoG_O5oz7WT14YGK70g/viewform" rel="noopener">
             Contact KubeKite
@@ -426,7 +369,8 @@
       </div>
       <div class="footer-links" aria-label="Footer links">
         <a href="#topics">Topics</a>
-        <a href="#insights">Insights</a>
+        <a href="#trends">Trends</a>
+        <a href="#repos">Repos</a>
         <a href="#about">About</a>
         <a href="#contact">Contact</a>
         <a href="https://www.linkedin.com/company/kubekite/" rel="noopener">LinkedIn</a>


### PR DESCRIPTION
Dark is now the default rather than an OS-dependent choice, and the site covers what actually gets published instead of a services pitch.

Theme:
- Move the dark palette onto bare :root and the light palette onto :root[data-theme="light"], so dark applies with no JS and no stored choice. Light is now an explicit opt-in.
- Delete both prefers-color-scheme blocks, including the ~30 duplicated token lines. The OS no longer influences the theme.
- Invert the toggle-face rules and currentTheme() to match, and drop the system-preference listener, which contradicted a fixed default.

Content:
- Remove the Insights, Latest, Why and Services sections. Latest was six placeholder posts with invented dates whose links went nowhere, and Why existed only to explain the knowledge-versus-services balance.
- Add Trends: what is moving across the software and computing landscape, across four beats, linking to the LinkedIn page where it is published.
- Add Repos: the kinds of open-source work being published, with the real workflow-builder repo and a link to the GitHub org. No invented names.
- Update nav, footer links, hero and contact copy to match.

Also remove the CSS left dead by those sections (services-* and article-*) and add the three small rules the new sections need.